### PR TITLE
Implemented JSONRPC 2.0 batch calls as per spec

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -102,3 +102,5 @@ Contributors
 - Michael Merickel, 1/30/2011
 
 - Atsushi Odagiri, 5/9/2011
+
+- Justus Wingert, solute GmbH, 11/07/2014

--- a/TODO.txt
+++ b/TODO.txt
@@ -3,7 +3,5 @@ pyramid_rpc README
 
 - Support system.* XML-RPC API Methods and introspection
 
-- Add support for batching requests via tweens.
-
 - Add support for traversal via '{rpc_method}' pattern to allow
   fine-grained security based on the rpc method or possible params.

--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -190,6 +190,8 @@ class jsonrpc_batch_tween(object):
 
                 # Dump the combined json response_body list into response.body
                 response.body = json.dumps(response_body)
+            else:
+                raise ValueError
         except ValueError:
             response = self.handler(request)
 

--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -15,6 +15,8 @@ from pyramid_rpc.mapper import MapplyViewMapper
 from pyramid_rpc.mapper import ViewMapperArgsInvalid
 from pyramid_rpc.util import combine
 
+from pyramid.tweens import EXCVIEW
+
 
 log = logging.getLogger(__name__)
 
@@ -460,7 +462,7 @@ def includeme(config):
     if not hasattr(config.registry, 'rpc_endpoints'):
         config.registry.rpc_endpoints = {}
 
-    config.add_tween('pyramid_rpc.jsonrpc.jsonrpc_batch_tween')
+    config.add_tween('pyramid_rpc.jsonrpc.jsonrpc_batch_tween', over=EXCVIEW)
 
     config.add_renderer(DEFAULT_RENDERER, jsonrpc_renderer)
     config.add_directive('add_jsonrpc_endpoint', add_jsonrpc_endpoint)


### PR DESCRIPTION
Implemented via Pyramid Tweens as suggested in TODO. All tests in test_jsonrpc.TestJSONRPCIntegration have been updated to work both batched and unbatched.

Testprotocol:
(acpdev)juw@juw:~/Projects/pyramid_rpc/pyramid_rpc/tests$ python -m unittest test_jsonrpc
...No handlers could be found for logger "pyramid_rpc.jsonrpc"
.....................................
----------------------------------------------------------------------
Ran 40 tests in 0.218s

OK