### PR TITLE
JSON-RPC batch support via subrequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - TOXENV=py2-docs
 #  - TOXENV=py3-docs
   - TOXENV=py2-cover,py3-cover,coverage
+  - TOXENV=py27-pyramid14
+  - TOXENV=py27-pyramid15
 
 install:
   - travis_retry pip install tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,11 @@ unreleased
 
   + Added Tox environments checking against older Pyramid versions.
 
+- JSON-RPC
+
+  + Added support for batched JSON-RPC requests (on POST requests only)
+    See https://github.com/Pylons/pyramid_rpc/pull/35
+
 0.5.3 (2015-05-14)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,18 @@
+unreleased
+==========
+
+- Pyramid version compatibility
+
+  + pyramid_rpc now requires Pyramid >= 1.4. (Version 0.5.3 will run on
+    Pyramid >= 1.2, but will not run on Pyramid 1.1.x despite what
+    setup.py indicates.)
+
+  + Removed pre-1.4 backwards compatibility for custom predicates.
+
+- Tox configuration
+
+  + Added Tox environments checking against older Pyramid versions.
+
 0.5.3 (2015-05-14)
 ==================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -102,3 +102,5 @@ Contributors
 - Michael Merickel, 1/30/2011
 
 - Atsushi Odagiri, 5/9/2011
+
+- Jon Rosebaugh, 5/14/2015

--- a/TODO.txt
+++ b/TODO.txt
@@ -3,7 +3,5 @@ pyramid_rpc README
 
 - Support system.* XML-RPC API Methods and introspection
 
-- Add support for batching requests via tweens.
-
 - Add support for traversal via '{rpc_method}' pattern to allow
   fine-grained security based on the rpc method or possible params.

--- a/docs/jsonrpc.rst
+++ b/docs/jsonrpc.rst
@@ -122,6 +122,18 @@ the ``method`` parameter:
 Because methods are a thin layer around Pyramid's views, it is possible to add
 extra view predicates to the method, as well as ``permission`` requirements.
 
+Handling JSON-RPC Batch Requests
+--------------------------------
+
+Batch requests are handled automatically. A JSON-RPC batch request consists
+of an array of regular JSON-RPC requests; the response will consist of an
+array of the responses.
+
+If there are no responses (which happens only when the request consisted
+entirely of notifications, to which there can be no response), the batch
+response is an empty body. This is not a valid JSON value, but the JSON-RPC
+spec does not provide for any other response in this situation.
+
 .. _jsonrpc_custom_renderers:
 
 Custom Renderers
@@ -174,6 +186,9 @@ example, to limit requests to only ``POST`` requests:
 .. code-block:: python
 
    config.add_jsonrpc_endpoint('api', '/api', request_method='POST')
+
+Batch requests are not supported via HTTP GET; there is no way to send multiple
+requests with the HTTP GET semantics.
 
 Handling JSONP Requests
 -----------------------

--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -297,11 +297,7 @@ def add_jsonrpc_endpoint(config, name, *args, **kw):
 
     config.registry.jsonrpc_endpoints[name] = endpoint
 
-    if hasattr(config, 'add_route_predicate'):
-        kw['jsonrpc_endpoint'] = True
-    else: # pragma: no cover (pyramid < 1.4)
-        predicates = kw.setdefault('custom_predicates', [])
-        predicates.append(EndpointPredicate(True, config))
+    kw['jsonrpc_endpoint'] = True
     config.add_route(name, *args, **kw)
     config.add_view(exception_view, route_name=name, context=Exception,
                     permission=NO_PERMISSION_REQUIRED)
@@ -360,11 +356,7 @@ def add_jsonrpc_method(config, view, **kw):
         renderer = endpoint.default_renderer
     kw['renderer'] = null_renderer
 
-    if hasattr(config, 'add_view_predicate'):
-        kw['jsonrpc_method'] = method
-    else: # pragma: no cover (pyramid < 1.4)
-        predicates = kw.setdefault('custom_predicates', [])
-        predicates.append(MethodPredicate(method, config))
+    kw['jsonrpc_method'] = method
 
     rpc_decorator = jsonrpc_view(renderer)
     decorator = kw.get('decorator', None)
@@ -441,10 +433,8 @@ def includeme(config):
     if not hasattr(config.registry, 'jsonrpc_endpoints'):
         config.registry.jsonrpc_endpoints = {}
 
-    if hasattr(config, 'add_view_predicate'):
-        config.add_view_predicate('jsonrpc_method', MethodPredicate)
-    if hasattr(config, 'add_route_predicate'):
-        config.add_route_predicate('jsonrpc_endpoint', EndpointPredicate)
+    config.add_view_predicate('jsonrpc_method', MethodPredicate)
+    config.add_route_predicate('jsonrpc_endpoint', EndpointPredicate)
 
     config.add_renderer(DEFAULT_RENDERER, jsonrpc_renderer)
     config.add_directive('add_jsonrpc_endpoint', add_jsonrpc_endpoint)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except:
 
 install_requires = [
     'venusian>=1.0a7',
-    'pyramid>=1.1',
+    'pyramid>=1.4',
 ]
 
 tests_require = install_requires + [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py26,py27,py32,py33,py34,pypy,pypy3,
     py2-docs,
-    {py2,py3}-cover,coverage
+    {py2,py3}-cover,coverage,
+    py27-pyramid{14,15}
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -17,6 +18,10 @@ basepython =
     pypy3: pypy3
     py2: python2.7
     py3: python3.4
+
+deps =
+    pyramid14: pyramid <= 1.4.99
+    pyramid15: pyramid <= 1.5.99
 
 commands =
     pip install pyramid_rpc[testing]


### PR DESCRIPTION
Comparing empty response handling in other implementations:

- [jsonrpc](https://github.com/pijyoi/jsonrpc) (C) returns either a null pointer or an empty string, depending on which layer you use.
- [tinyrpc](https://github.com/mbr/tinyrpc) (Python) supports batch requests, but not batch responses, making the point moot
- [AFJSONRPCClient](https://github.com/AFNetworking/AFJSONRPCClient) (Objective-C) does not support batch requests or responses
- [go/net/rpc/jsonrpc](http://golang.org/pkg/net/rpc/jsonrpc/) (golang) doesn't seem to support batch either
- [jsonrpc4j](https://github.com/briandilley/jsonrpc4j) (Java) sends an empty array, in violation of the spec
- [jrpc2](https://github.com/Santinell/jrpc2) (Node.js) client does not support notifications in batch requests; server appears to return an empty array, in violation of the spec
- [objc-JSONRpc](https://github.com/styrken/objc-JSONRpc) (Objective-C) supports only regular requests in batch mode, not notifications
- [jimson](https://github.com/chriskite/jimson) (Ruby) correctly sends an empty body if there is no response, but its client assumes the body is not empty and is valid JSON. Did they test this?