### PR TITLE
Changes EndpointPredicate to a ContextFound subscriber

### DIFF
--- a/pyramid_rpc/tests/fixtures/simplerpc.py
+++ b/pyramid_rpc/tests/fixtures/simplerpc.py
@@ -14,7 +14,9 @@ class Root(dict):
 
     def __init__(self, request):
         self.request = request
-        self.__acl__ = ACLS.get(request.rpc_method)
+
+    def __acl__(self):
+        return ACLS.get(self.request.rpc_method)
 
 def basic(request):
     return 'basic'


### PR DESCRIPTION
Unfortunately this means `__acls__` has to be a callable if it wants to access `request.rpc_method` or similar. And `__acls__` can't be a callable in Pyramid 1.4.

So this is not the way forward, but I wanted to save this work anyway.