### PR TITLE
Prevent AttributeError in MethodPredicate

### DIFF
--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -267,7 +267,7 @@ class MethodPredicate(object):
     phash = text
 
     def __call__(self, context, request):
-        return getattr(request, 'rpc_method') == self.method
+        return getattr(request, 'rpc_method', None) == self.method
 
 
 class BatchedRequestPredicate(object):


### PR DESCRIPTION
Pyramid orders views based on the number and kind of predicates. In the
test, the batched view was always appearing first, but in some
real-world cases, it would not. When a method predicate ran, it would
try to get the 'rpc_method' attribute from the request and fail, raising
an AttributeError.

Fixes #39.