### PR TITLE
Remove Content-Length from headers when handling batched subrequests

### DIFF
--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import copy
 
 import venusian
 from pyramid.exceptions import ConfigurationError
@@ -289,10 +290,12 @@ def batched_request_view(request):
     response = request.response
     for rpc_request in request.batched_rpc_requests:
         body = json.dumps(rpc_request).encode(request.charset)
+        subrequest_headers = copy.copy(request.headers)
+        subrequest_headers.pop('Content-Length', None)
         subrequest = Request.blank(path=request.path,
                                    environ=request.environ,
                                    base_url=request.application_url,
-                                   headers=request.headers,
+                                   headers=subrequest_headers,
                                    POST=body,
                                    charset=request.charset)
         subresponse = request.invoke_subrequest(subrequest, use_tweens=True)

--- a/pyramid_rpc/tests/test_jsonrpc.py
+++ b/pyramid_rpc/tests/test_jsonrpc.py
@@ -154,7 +154,7 @@ class TestJSONRPCIntegration(unittest.TestCase):
         result1 = [r for r in result if r['id'] == 1][0]
         result2 = [r for r in result if r['id'] == 2][0]
         self.assertEqual(result1, {'id': 1, 'jsonrpc': '2.0', 'result': [0]})
-        self.assertEqual(result2, {'id': 2, 'jsonrpc': '2.0', 'result': [range(100)]})
+        self.assertEqual(result2, {'id': 2, 'jsonrpc': '2.0', 'result': [[x for x in range(100)]]})
 
     def test_it_with_batched_requests_and_more_predicates(self):
         # View ordering is determined partially by number of predicates

--- a/pyramid_rpc/tests/test_jsonrpc.py
+++ b/pyramid_rpc/tests/test_jsonrpc.py
@@ -133,6 +133,29 @@ class TestJSONRPCIntegration(unittest.TestCase):
         self.assertEqual(result1, {'id': 1, 'jsonrpc': '2.0', 'result': [2, 3]})
         self.assertEqual(result2, {'id': 2, 'jsonrpc': '2.0', 'result': [3, 2]})
 
+    def test_it_with_batched_requests_and_content_length(self):
+        def view(request, a):
+            return [a]
+        config = self.config
+        config.include('pyramid_rpc.jsonrpc')
+        config.add_jsonrpc_endpoint('rpc', '/api/jsonrpc')
+        config.add_jsonrpc_method(view, endpoint='rpc', method='dummy')
+        app = config.make_wsgi_app()
+        app = TestApp(app)
+        body = [
+            {'id': 1, 'jsonrpc': '2.0', 'method': 'dummy', 'params': [0]},
+            {'id': 2, 'jsonrpc': '2.0', 'method': 'dummy', 'params': [range(100)]},
+        ]
+        json_body = json.dumps(body, separators=(',',':'))
+        resp = app.post('/api/jsonrpc', content_type='application/json',
+                        headers={'Content-Length': str(len(json_body))}, params=json_body)
+        self.assertEqual(resp.status_int, 200)
+        result = resp.json
+        result1 = [r for r in result if r['id'] == 1][0]
+        result2 = [r for r in result if r['id'] == 2][0]
+        self.assertEqual(result1, {'id': 1, 'jsonrpc': '2.0', 'result': [0]})
+        self.assertEqual(result2, {'id': 2, 'jsonrpc': '2.0', 'result': [range(100)]})
+
     def test_it_with_batched_requests_and_more_predicates(self):
         # View ordering is determined partially by number of predicates
         class MoodPredicate(object):

--- a/pyramid_rpc/tests/test_jsonrpc.py
+++ b/pyramid_rpc/tests/test_jsonrpc.py
@@ -144,7 +144,7 @@ class TestJSONRPCIntegration(unittest.TestCase):
         app = TestApp(app)
         body = [
             {'id': 1, 'jsonrpc': '2.0', 'method': 'dummy', 'params': [0]},
-            {'id': 2, 'jsonrpc': '2.0', 'method': 'dummy', 'params': [range(100)]},
+            {'id': 2, 'jsonrpc': '2.0', 'method': 'dummy', 'params': [[x for x in range(100)]]},
         ]
         json_body = json.dumps(body, separators=(',',':'))
         resp = app.post('/api/jsonrpc', content_type='application/json',


### PR DESCRIPTION
We noticed this issue when processing a batched JSON-RPC request originating from chrome with two requests in the batch. The first was quite short, and the second had a lot of parameters and so was very long. We were getting a JsonRpcParseError when trying to process the second request. The issue is that pyramid_rpc is blindly passing all of the original request headers to the Request.blank for the subrequest, including the Content-Length as supplied by chrome. Because chrome serializes JSON with no spaces after separators, but python's json module by default adds spaces after , and :, the actual size of the 2nd subrequest body is *larger* than the Content-Length provided by the browser, so webob does not read all of the body of the 2nd request, resulting in the parse error.

The fix here copies the headers for each subrequest and removes the Content-Length header if it exists. I'm not quite sure how to unit test this, as it seems the test suite here doesn't actually use webob.