### PR TITLE
Make handling of exceptions user tunable.

### DIFF
--- a/pyramid_rpc/tests/test_xmlrpc.py
+++ b/pyramid_rpc/tests/test_xmlrpc.py
@@ -138,9 +138,9 @@ class TestXMLRPCIntegration(unittest.TestCase):
         config.add_xmlrpc_endpoint('rpc', '/api/xmlrpc')
         app = config.make_wsgi_app()
         app = TestApp(app)
-        resp = app.post('/api/xmlrpc', content_type='text/xml',
-                        params='<')
         try:
+            resp = app.post('/api/xmlrpc', content_type='text/xml',
+                            params='<', status="*")
             xmlrpclib.loads(resp.body)
         except xmlrpclib.Fault:
             exc = sys.exc_info()[1] # 2.5 compat
@@ -193,6 +193,19 @@ class TestXMLRPCIntegration(unittest.TestCase):
         app = TestApp(app)
         resp = self._callFUT(app, 'dummy', (2, 3))
         self.assertEqual(resp, [2, 3, 'bar'])
+
+    def test_it_listMethods(self):
+        def view(request, a, b):
+            return [a, b]
+        config = self.config
+        config.include('pyramid_rpc.xmlrpc')
+        config.add_xmlrpc_endpoint('rpc', '/api/xmlrpc')
+        config.add_xmlrpc_method(view, endpoint='rpc', method='dummy')
+        app = config.make_wsgi_app()
+        app = TestApp(app)
+        resp = self._callFUT(app, 'system.listMethods', ())
+        print(resp)
+        assert(False)
 
     def test_it_with_missing_args(self):
         config = self.config

--- a/pyramid_rpc/tests/test_xmlrpc.py
+++ b/pyramid_rpc/tests/test_xmlrpc.py
@@ -204,8 +204,20 @@ class TestXMLRPCIntegration(unittest.TestCase):
         app = config.make_wsgi_app()
         app = TestApp(app)
         resp = self._callFUT(app, 'system.listMethods', ())
-        print(resp)
-        assert(False)
+        assert ('dummy' in resp and 'system.listMethods' in resp)
+
+    def test_it_methodHelp(self):
+        def view(request, a, b):
+            return [a, b]
+        config = self.config
+        config.include('pyramid_rpc.xmlrpc')
+        config.add_xmlrpc_endpoint('rpc', '/api/xmlrpc')
+        config.add_xmlrpc_method(view, endpoint='rpc', method='dummy',
+                                 help="Helpful.")
+        app = config.make_wsgi_app()
+        app = TestApp(app)
+        resp = self._callFUT(app, 'system.methodHelp', ("dummy",))
+        assert(resp == "Helpful.")
 
     def test_it_with_missing_args(self):
         config = self.config

--- a/pyramid_rpc/xmlrpc.py
+++ b/pyramid_rpc/xmlrpc.py
@@ -168,7 +168,7 @@ def add_xmlrpc_endpoint(config, name, *args, **kw):
     """
     default_mapper = kw.pop('default_mapper', MapplyViewMapper)
     default_renderer = kw.pop('default_renderer', DEFAULT_RENDERER)
-
+    default_exception_view = kw.pop('default_exception_view',exception_view)
     endpoint = Endpoint(
         name,
         default_mapper=default_mapper,
@@ -179,7 +179,7 @@ def add_xmlrpc_endpoint(config, name, *args, **kw):
     kw['xmlrpc_endpoint'] = True
 
     config.add_route(name, *args, **kw)
-    config.add_view(exception_view, route_name=name, context=Exception,
+    config.add_view(default_exception_view, route_name=name, context=Exception,
                     permission=NO_PERMISSION_REQUIRED,
                     renderer=endpoint.default_renderer)
 
@@ -307,6 +307,3 @@ def includeme(config):
     config.add_directive('add_xmlrpc_endpoint', add_xmlrpc_endpoint)
     config.add_directive('add_xmlrpc_method', add_xmlrpc_method)
     config.add_renderer(name=DEFAULT_RENDERER, factory=XMLRPCRenderer())
-    config.add_view(exception_view, context=xmlrpclib.Fault,
-                    permission=NO_PERMISSION_REQUIRED,
-                    renderer=DEFAULT_RENDERER)


### PR DESCRIPTION
I should start out by saying that I am not sure that this is the correct way to do this. That said, I needed a way to indicate to the client that they were being denied access to a method due to insufficient privilege. After looking at the source code, it appeared that the behavior of exception handling had been baked into pyramid_rpc.xmlrpc. I made the following changes so that I could muck about with how exceptions would be handled. I am sending this pull request just in case it provides a useful example of how people might use pyramid_rpc.xmlrpc.
