### PR TITLE
Python 3.12 raises KeyError instead of TypeError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+- JSON-RPC
+
+  + Python 3.12 compatibility: Detection of a batched request used catching
+    for TypeError prior to Python 3.12. Since Python 3.12, KeyError is raised
+    on a bad slice index. This has been fixed to catch both exceptions.
+
 0.8 (2016-10-31)
 ================
 

--- a/pyramid_rpc/jsonrpc.py
+++ b/pyramid_rpc/jsonrpc.py
@@ -193,6 +193,8 @@ def parse_request_POST(request):
         batched = body[:]
     except TypeError:
         batched = None
+    except KeyError:
+        batched = None
 
     if batched is not None:
         request.batched_rpc_requests = batched


### PR DESCRIPTION
Python 3.12 compatibility: Detection of a batched request used catching for TypeError prior to Python 3.12. Since Python 3.12, KeyError is raised on a bad slice index. This has been fixed to catch both exceptions.

In Python 3.12 jsonrpc did not work at all.